### PR TITLE
Introducing the Create Release Notes action (force release)

### DIFF
--- a/Source/action.ts
+++ b/Source/action.ts
@@ -50,7 +50,6 @@ function output(
     setOutput('plaintext', plaintext);
 }
 
-
 function fail(error: Error) {
     logger.error(error.message);
     setFailed(error.message);


### PR DESCRIPTION
## Summary

This first release introduces the Create Release Notes action. It receives a release summary, a version and an optional changelog URL and modifies the release summary to say which version was released in the header, and adds a link to the changelog at the bottom.

These are rendered both back to the original Markdown format, and as a plain text string - to be used for release notes in packages such as NuGet.