### PR TITLE
Add output formatters

### DIFF
--- a/Source/IFormatOutputs.ts
+++ b/Source/IFormatOutputs.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Defines a system that can format output strings.
+ */
+export interface IFormatOutputs {
+
+    /**
+     * The format type this formatter formats.
+     */
+    readonly type: string;
+
+    /**
+     * Formats the provided output string.
+     * @param output The output string to format.
+     * @returns A new formatted string.
+     */
+    format(output: string): string;
+}
+

--- a/Source/IOutputFormatters.ts
+++ b/Source/IOutputFormatters.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IFormatOutputs } from './IFormatOutputs';
+import { OutputFormat } from './OutputFormat';
+
+/**
+ * Defines a system that can knows about { @link IFormatOutputs }.
+ */
+export interface IOutputFormatters {
+    /**
+     * Checks whether a formatter is defined for the specified output format.
+     * @param type The output format type.
+     */
+    canFormat(type: OutputFormat): boolean;
+
+    /**
+     * Formats the provided output string using the specified output format.
+     * @param type The output format type.
+     * @param output The output string to format.
+     * @returns A new formatted string.
+     */
+    format(type: OutputFormat, output: string): string;
+}
+

--- a/Source/MSbuildOutputFormatter.ts
+++ b/Source/MSbuildOutputFormatter.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IFormatOutputs } from './IFormatOutputs';
+
+/**
+ * Represents an implementation of { @link IFormatOutputs } that escapes commas and semicolons for MSbuild arguments.
+ */
+export class MSbuildOutputFormatter implements IFormatOutputs {
+    /** @inheritdoc */
+    readonly type: string = 'msbuild';
+
+    /** @inheritdoc */
+    format(output: string): string {
+        return output.replace(/,/g, '%2C').replace(/;/g, '%3B');
+    }
+}

--- a/Source/MultipleFormattersDefinedFor.ts
+++ b/Source/MultipleFormattersDefinedFor.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { OutputFormat } from './OutputFormat';
+
+/**
+ * The exception that gets thrown when multiple output formatters is defined for the same type.
+ */
+ export class MultipleFormattersDefinedFor extends Error {
+    /**
+     * Initializes a new instance of {@link MultipleFormattersDefinedFor}
+     * @param type The format type.
+     */
+    constructor(type: OutputFormat, original: Function, duplicate: Function) {
+        super(`The format type '${type}' has multiple formatters defined. The original is '${original.name}' and the duplicate is '${duplicate.name}'`);
+    }
+}

--- a/Source/NoFormatterDefinedFor.ts
+++ b/Source/NoFormatterDefinedFor.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { OutputFormat } from './OutputFormat';
+
+/**
+ * The exception that gets thrown when trying to format output with a format type that has not formatter defined.
+ */
+ export class NoFormatterDefinedFor extends Error {
+    /**
+     * Initializes a new instance of {@link NoFormatterDefinedFor}
+     * @param type The format type.
+     */
+    constructor(type: OutputFormat) {
+        super(`The format type '${type}' has not formatter defined`);
+    }
+}

--- a/Source/OutputFormat.ts
+++ b/Source/OutputFormat.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents the output format of the release notes.
+ */
+export type OutputFormat = string;

--- a/Source/OutputFormatters.ts
+++ b/Source/OutputFormatters.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IFormatOutputs } from './IFormatOutputs';
+import { IOutputFormatters } from './IOutputFormatters';
+import { MultipleFormattersDefinedFor } from './MultipleFormattersDefinedFor';
+import { NoFormatterDefinedFor } from './NoFormatterDefinedFor';
+import { OutputFormat } from './OutputFormat';
+
+export class OutputFormatters implements IOutputFormatters {
+    private readonly _formatters: Map<OutputFormat, IFormatOutputs>;
+
+    constructor(...formatters: IFormatOutputs[]) {
+        this._formatters = new Map<OutputFormat, IFormatOutputs>();
+
+        for (const formatter of formatters) {
+            const type = formatter.type;
+            if (this._formatters.has(type)) {
+                throw new MultipleFormattersDefinedFor(type, (this._formatters.get(type) as Object).constructor, (formatter as Object).constructor);
+            }
+
+            this._formatters.set(type, formatter);
+        }
+    }
+
+    /** @inheritdoc */
+    canFormat(type: OutputFormat): boolean {
+        return this._formatters.has(type);
+    }
+
+    /** @inheritdoc */
+    format(type: OutputFormat, output: string): string {
+        this.throwIfNoFormatterDefinedFor(type);
+        return this._formatters.get(type)!.format(output);
+    }
+
+    private throwIfNoFormatterDefinedFor(type: OutputFormat) {
+        if (!this._formatters.has(type)) {
+            throw new NoFormatterDefinedFor(type);
+        }
+    }
+}

--- a/Source/RawOutputFormatter.ts
+++ b/Source/RawOutputFormatter.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IFormatOutputs } from './IFormatOutputs';
+
+/**
+ * Represents an implementation of { @link IFormatOutputs } that passes the output straight through.
+ */
+export class RawOutputFormatter implements IFormatOutputs {
+    /** @inheritdoc */
+    readonly type: string = 'raw';
+
+    /** @inheritdoc */
+    format(output: string): string {
+        return output;
+    }
+}

--- a/Source/for_MSbuildOutputFormatter/when_formatting.ts
+++ b/Source/for_MSbuildOutputFormatter/when_formatting.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { MSbuildOutputFormatter } from '../MSbuildOutputFormatter';
+
+describe('for MSbuildOutputFormatter', () => {
+    describe('when formatting', () => {
+        const formatter = new MSbuildOutputFormatter();
+
+        const output = 'Some very complicated; ,, string! 😁';
+        const expected = 'Some very complicated%3B %2C%2C string! 😁';
+
+        const result = formatter.format(output);
+
+        it('should pass the output straight through', () => expect(result).to.equal(expected));
+    });
+});

--- a/Source/for_OutputFormatters/given/some_output_formatters.ts
+++ b/Source/for_OutputFormatters/given/some_output_formatters.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as sinon from 'ts-sinon';
+
+import { IFormatOutputs } from '../../IFormatOutputs';
+
+class MockFormatter implements IFormatOutputs {
+    constructor(readonly type: string) {}
+
+    format(output: string): string {
+        return output;
+    }
+}
+
+export const a_raw_formatter = () => sinon.stubObject(new MockFormatter('raw'));
+
+export const another_raw_formatter = () => sinon.stubObject(new MockFormatter('raw'));
+
+export const an_msbuild_formatter = () => sinon.stubObject(new MockFormatter('msbuild'));

--- a/Source/for_OutputFormatters/when_checking_if_can_format.ts
+++ b/Source/for_OutputFormatters/when_checking_if_can_format.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { OutputFormatters } from '../OutputFormatters';
+import { an_msbuild_formatter, a_raw_formatter } from './given/some_output_formatters';
+
+
+describe('for OutputFormatters', () => {
+    const formatters = new OutputFormatters(a_raw_formatter(), an_msbuild_formatter());
+
+    describe('when checking if can format for a formatter that is provided', () => {
+        const result = formatters.canFormat(a_raw_formatter().type);
+
+        it('should return true', () => expect(result).to.be.true);
+    });
+
+    describe('when checking if can format for a formatter that is not provided', () => {
+        const result = formatters.canFormat('some other type');
+
+        it('should return false', () => expect(result).to.be.false);
+    });
+});

--- a/Source/for_OutputFormatters/when_constructing_from_multiple_formatters_are_defined_for_different_types.ts
+++ b/Source/for_OutputFormatters/when_constructing_from_multiple_formatters_are_defined_for_different_types.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { OutputFormatters } from '../OutputFormatters';
+import { an_msbuild_formatter, a_raw_formatter } from './given/some_output_formatters';
+
+
+describe('for OutputFormatters', () => {
+    describe('when constructing from multiple formatters are defined for diffent_types', () => {
+        let exception: unknown;
+        try {
+            new OutputFormatters(a_raw_formatter(), an_msbuild_formatter());
+        } catch (error) {
+            exception = error;
+        }
+
+        it('should fail not fail', () => expect(exception).to.be.undefined);
+    });
+});

--- a/Source/for_OutputFormatters/when_constructing_from_multiple_formatters_are_defined_for_the_same_type.ts
+++ b/Source/for_OutputFormatters/when_constructing_from_multiple_formatters_are_defined_for_the_same_type.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { MultipleFormattersDefinedFor } from '../MultipleFormattersDefinedFor';
+import { OutputFormatters } from '../OutputFormatters';
+import { another_raw_formatter, a_raw_formatter } from './given/some_output_formatters';
+
+
+describe('for OutputFormatters', () => {
+    describe('when constructing from multiple formatters are defined for the same type', () => {
+        let exception: unknown;
+        try {
+            new OutputFormatters(a_raw_formatter(), another_raw_formatter());
+        } catch (error) {
+            exception = error;
+        }
+
+        it('should fail', () => expect(exception).to.be.instanceOf(MultipleFormattersDefinedFor));
+    });
+});

--- a/Source/for_OutputFormatters/when_formatting.ts
+++ b/Source/for_OutputFormatters/when_formatting.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { OutputFormatters } from '../OutputFormatters';
+import { an_msbuild_formatter, a_raw_formatter } from './given/some_output_formatters';
+
+
+describe('for OutputFormatters', () => {
+    describe('when formatting', () => {
+        const raw_formatter = a_raw_formatter();
+        const msbuild_formatter = an_msbuild_formatter();
+        const formatters = new OutputFormatters(raw_formatter, msbuild_formatter);
+
+        raw_formatter.format.returns('raw format result');
+        msbuild_formatter.format.returns('msbuild format result');
+
+        const type = raw_formatter.type;
+        const output = 'some_input string is here';
+
+        const result = formatters.format(type, output);
+
+        it('should call the raw formatter', () => expect(raw_formatter.format).to.be.calledOnceWith(output));
+        it('should not call the msbuild formatter', () => expect(msbuild_formatter.format).to.not.be.called);
+        it('should return the result from the raw formatter', () => expect(result).to.equal('raw format result'));
+    });
+});

--- a/Source/for_OutputFormatters/when_formatting_with_a_formatter_that_is_not_provided.ts
+++ b/Source/for_OutputFormatters/when_formatting_with_a_formatter_that_is_not_provided.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+import { NoFormatterDefinedFor } from '../NoFormatterDefinedFor';
+
+import { OutputFormatters } from '../OutputFormatters';
+import { an_msbuild_formatter, a_raw_formatter } from './given/some_output_formatters';
+
+
+describe('for OutputFormatters', () => {
+    describe('when formatting with a formatter that is not provided', () => {
+        const formatters = new OutputFormatters(a_raw_formatter(), an_msbuild_formatter());
+
+        let exception: unknown;
+        try {
+            formatters.format('some other format', 'some output string');
+        } catch (error) {
+            exception = error;
+        }
+
+        it('should fail', () => expect(exception).to.be.instanceOf(NoFormatterDefinedFor));
+    });
+});

--- a/Source/for_RawOutputFormatter/when_formatting.ts
+++ b/Source/for_RawOutputFormatter/when_formatting.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { expect } from 'chai';
+
+import { RawOutputFormatter } from '../RawOutputFormatter';
+
+describe('for RawOutputFormatter', () => {
+    describe('when formatting', () => {
+        const formatter = new RawOutputFormatter();
+
+        const output = 'Some very complicated; , string! 😁';
+
+        const result = formatter.format(output);
+
+        it('should pass the output straight through', () => expect(result).to.equal(output));
+    });
+});

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   changelog-url:
     description: Link to the full changelog to append to the release notes
     required: false
+  output-format:
+    description: Output format used for special treament of output strings. Can be "raw" or "msbuild", defaults to "raw".
+    required: false
 
 outputs:
   markdown:

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
   },
   "devDependencies": {
     "@dolittle/typescript.build": "5.3.6",
-    "@types/marked": "3.0.2",
     "@types/he": "1.1.2",
+    "@types/marked": "3.0.2",
     "@zeit/ncc": "0.22.3",
-    "del-cli": "3.0.1"
+    "del-cli": "3.0.1",
+    "ts-sinon": "2.0.2"
   },
   "dependencies": {
     "@actions/core": "1.2.4",


### PR DESCRIPTION
## Summary

Introducing output formatters to cater to special string handling of different build tools.

### Added

- Input parameter to select output formatting
- Raw output formatting for doing noting with the output string (default)
- MSbuild output formatter that escapes commas and semicolons
