### PR TITLE
Escape '"' and '&' for MSbuild format.

### DIFF
--- a/Source/MSbuildOutputFormatter.ts
+++ b/Source/MSbuildOutputFormatter.ts
@@ -12,6 +12,10 @@ export class MSbuildOutputFormatter implements IFormatOutputs {
 
     /** @inheritdoc */
     format(output: string): string {
-        return output.replace(/,/g, '%2C').replace(/;/g, '%3B');
+        return output
+            .replace(/,/g, '%2C')
+            .replace(/;/g, '%3B')
+            .replace(/"/g, '%22')
+            .replace(/&/g, '%26');
     }
 }


### PR DESCRIPTION
## Summary

Escapes `"` and `&` characters when outputting MSbuild format.

### Fixed

- Release notes with `"` or `&` characters broke `dotnet pack` command.
